### PR TITLE
[Build] Add extraArgs to Dockerfile Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm install --ignore-scripts
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
After several attempts, I see that with this parameter it finally creates the image for me.

I've been testing it using stdio/stdout and it works perfectly.

Models such as Claude Code and Cline's Free use with the addition of an MCP Server Remote.


<img width="573" height="395" alt="image" src="https://github.com/user-attachments/assets/99bcac7f-a524-43ee-92ab-ef74e6da4d19" />


And the config that I use:

<img width="605" height="387" alt="image" src="https://github.com/user-attachments/assets/ab9b08c0-6a3a-4be5-a81b-b8a7ff717387" />
