### PR TITLE
feat(server): add header-based api url config

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ Add the following MCP definition to your configuration:
 }
 ```
 
-### Authentication
+### Authentication & Configuration
 
-The Outline MCP server supports two authentication methods:
+The Outline MCP server supports flexible configuration for both authentication and API endpoint selection:
+
+#### API Key Authentication
 
 1. **Environment Variable (Required for stdio mode)**: Set `OUTLINE_API_KEY` as an environment variable
 2. **Request Headers (HTTP/SSE modes)**: Provide the API key in request headers
@@ -104,15 +106,27 @@ For **HTTP/SSE modes**, you have two options:
 - Set `OUTLINE_API_KEY` as an environment variable (fallback method)
 - Provide API key in request headers (recommended for per-request authentication)
 
-#### Header-based Authentication
+#### Header-based Authentication & API URL
 
-When using HTTP/SSE endpoints, you can provide the API key using any of these headers:
+When using HTTP/SSE endpoints, you can provide the API key and API URL using headers for **per-request configuration**:
 
+**API Key headers:**
 - `x-outline-api-key: your_api_key_here`
 - `outline-api-key: your_api_key_here`
 - `authorization: Bearer your_api_key_here`
 
-If no header is provided, the server will fall back to the `OUTLINE_API_KEY` environment variable. If neither is available, the request will fail with an authentication error.
+**API URL headers (for multi-tenant or self-hosted instances):**
+- `x-outline-api-url: https://your-company.getoutline.com/api`
+- `outline-api-url: https://your-company.getoutline.com/api`
+
+This allows a single MCP server instance to work with multiple Outline workspaces or self-hosted instances. Each request can specify its own API key and URL.
+
+**Priority order:**
+1. Request headers (highest priority)
+2. Environment variables
+3. Default values (for API URL only: `https://app.getoutline.com/api`)
+
+If no API key is provided via headers or environment variables, the request will fail with an authentication error.
 
 ### Env vars
 

--- a/src/outline/outlineClient.ts
+++ b/src/outline/outlineClient.ts
@@ -7,20 +7,21 @@ import { RequestContext } from '../utils/toolRegistry.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 config({ path: join(__dirname, '..', '.env') });
 
-const API_URL = process.env.OUTLINE_API_URL || 'https://app.getoutline.com/api';
+const DEFAULT_API_URL = 'https://app.getoutline.com/api';
 
 /**
- * Creates an Outline API client with the specified API key
+ * Creates an Outline API client with the specified API key and URL
  */
-export function createOutlineClient(apiKey?: string): AxiosInstance {
+export function createOutlineClient(apiKey?: string, apiUrl?: string): AxiosInstance {
   const key = apiKey || process.env.OUTLINE_API_KEY;
+  const url = apiUrl || process.env.OUTLINE_API_URL || DEFAULT_API_URL;
 
   if (!key) {
     throw new Error('OUTLINE_API_KEY must be provided either as parameter or environment variable');
   }
 
   return axios.create({
-    baseURL: API_URL,
+    baseURL: url,
     headers: {
       Authorization: `Bearer ${key}`,
       'Content-Type': 'application/json',
@@ -30,14 +31,15 @@ export function createOutlineClient(apiKey?: string): AxiosInstance {
 }
 
 /**
- * Gets an outline client using context API key first, then environment variable
+ * Gets an outline client using context API key and URL first, then environment variables
  */
 export function getOutlineClient(): AxiosInstance {
   const context = RequestContext.getInstance();
   const contextApiKey = context.getApiKey();
+  const contextApiUrl = context.getApiUrl();
 
-  if (contextApiKey) {
-    return createOutlineClient(contextApiKey);
+  if (contextApiKey || contextApiUrl) {
+    return createOutlineClient(contextApiKey, contextApiUrl);
   }
 
   return createOutlineClient();

--- a/src/utils/toolRegistry.ts
+++ b/src/utils/toolRegistry.ts
@@ -44,6 +44,14 @@ export class RequestContext {
   setApiKey(apiKey: string): void {
     this.set('apiKey', apiKey);
   }
+
+  getApiUrl(): string | undefined {
+    return this.get('apiUrl');
+  }
+
+  setApiUrl(apiUrl: string): void {
+    this.set('apiUrl', apiUrl);
+  }
 }
 
 class ToolRegistry {


### PR DESCRIPTION
Adds support for configuring the API URL via a request header, enabling dynamic server selection without changing startup configuration.