### PR TITLE
fix: correct default offset in listDocuments to not skip first document

### DIFF
--- a/src/tools/listDocuments.ts
+++ b/src/tools/listDocuments.ts
@@ -31,7 +31,7 @@ toolRegistry.register('list_documents', {
     try {
       // Create the payload object
       const payload: Record<string, any> = {
-        offset: args.offset || 1,
+        offset: args.offset ?? 0,
         limit: args.limit || 25,
         sort: args.sort || 'updatedAt',
         direction: args.direction || 'DESC',


### PR DESCRIPTION
Problem
The list_documents tool skips the first document in any collection because the default offset is incorrectly set to 1 instead of 0.
In src/tools/listDocuments.ts line 34:
typescriptoffset: args.offset || 1,
This causes two issues:

The default offset is 1, which skips the first document
Using || means even explicitly passing offset: 0 gets overridden to 1 (since 0 is falsy)

Fix
Change line 34 to:
typescriptoffset: args.offset ?? 0,
Using nullish coalescing (??) ensures 0 is respected when passed explicitly, and the default is correctly 0.
Reproduction

Create a collection with 2+ documents
Call list_documents with that collection ID
Notice the response shows offset: 1 in pagination and is missing the first document
Search for the missing document — it exists but isn't returned by list