### PR TITLE
fix: add quiet option to dotenv config to prevent stdout pollution in stdio mode

### DIFF
--- a/src/outline/outlineClient.ts
+++ b/src/outline/outlineClient.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 import { RequestContext } from '../utils/toolRegistry.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-config({ path: join(__dirname, '..', '.env') });
+config({ path: join(__dirname, '..', '.env'), quiet: true });
 
 const API_URL = process.env.OUTLINE_API_URL || 'https://app.getoutline.com/api';
 


### PR DESCRIPTION
When using the DXT extension in Claude Desktop, dotenv v17 outputs status messages to stdout like "[dotenv@17.2.3] injecting env (0) from .../.env -- tip: sync secrets..." This corrupts the MCP JSON stream, causing the error "Unexpected token 'd', "[dotenv@17."... is not valid JSON"
The fix adds quiet: true to the dotenv config call in src/outline/outlineClient.ts line 8, changing config({ path: join(__dirname, '..', '.env') }) to config({ path: join(__dirname, '..', '.env'), quiet: true }). This suppresses dotenv's stdout output while preserving its functionality.