### PR TITLE
feat(tools): add list_comments tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This MCP server can be added to just about any agent with an appropriate command
   - ✅ Create and update collections
 
 - **Comment Management**
+  - ✅ List comments for documents and collections
   - ✅ Create comments on documents
   - ✅ Update existing comments
   - ✅ Delete comments

--- a/src/tools/listComments.ts
+++ b/src/tools/listComments.ts
@@ -1,0 +1,70 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getOutlineClient } from '../outline/outlineClient.js';
+import toolRegistry from '../utils/toolRegistry.js';
+import z from 'zod';
+
+toolRegistry.register('list_comments', {
+  name: 'list_comments',
+  description: 'List comments for a document or collection in the Outline workspace',
+  inputSchema: {
+    documentId: z.string().describe('Filter by document ID').optional(),
+    collectionId: z.string().describe('Filter by collection ID').optional(),
+    includeAnchorText: z
+      .boolean()
+      .describe(
+        'Include the highlighted document text that the comment is anchored to (default true)',
+      )
+      .optional(),
+    limit: z.number().describe('Maximum number of comments to return (default 25)').optional(),
+    offset: z.number().describe('Pagination offset (default 0)').optional(),
+    sort: z
+      .string()
+      .describe('Field to sort by, e.g. "createdAt" (default "createdAt")')
+      .optional(),
+    direction: z
+      .enum(['ASC', 'DESC'])
+      .describe('Sort direction, either "ASC" or "DESC" (default "DESC")')
+      .optional(),
+  },
+  async callback(args) {
+    try {
+      const payload: Record<string, any> = {
+        offset: args.offset ?? 0,
+        limit: args.limit || 25,
+        sort: args.sort || 'createdAt',
+        direction: args.direction || 'DESC',
+      };
+
+      if (args.documentId) {
+        payload.documentId = args.documentId;
+      }
+
+      if (args.collectionId) {
+        payload.collectionId = args.collectionId;
+      }
+
+      payload.includeAnchorText = args.includeAnchorText ?? true;
+
+      const client = getOutlineClient();
+      const response = await client.post('/comments.list', payload);
+
+      const comments = response.data.data;
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `comments: ${JSON.stringify(comments)}`,
+          },
+          {
+            type: 'text',
+            text: `pagination: ${JSON.stringify(response.data.pagination)}`,
+          },
+        ],
+      };
+    } catch (error: any) {
+      console.error('Error listing comments:', error.message);
+      throw new McpError(ErrorCode.InvalidRequest, error.message);
+    }
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `list_comments` tool for listing comments on documents and collections
- Supports all `comments.list` API parameters: filtering by document/collection, pagination, sorting
- Defaults `includeAnchorText` to `true` so anchored comments include the highlighted document text

## Test plan

- [ ] Call `list_comments` with a `documentId` — verify comments returned with anchor text
- [ ] Call `list_comments` with pagination (`limit`, `offset`) — verify correct subset returned
- [ ] Call `list_comments` with `includeAnchorText: false` — verify `anchorText` field is absent
- [ ] Call `list_comments` with no filters — verify all workspace comments returned